### PR TITLE
Update sensu repo

### DIFF
--- a/repos/sensu.sls
+++ b/repos/sensu.sls
@@ -8,7 +8,7 @@ sensu-apt-key:
   cmd:
     - run
     - name: apt-key add /var/tmp/sensu.key
-    - unless: apt-key list | grep '2048R/7580C77F.*expires'
+    - unless: apt-key list | grep '2048R/7580C77F.*'
 
 sensu-deb:
   pkgrepo.absent:

--- a/repos/sensu.sls
+++ b/repos/sensu.sls
@@ -10,11 +10,20 @@ sensu-apt-key:
     - name: apt-key add /var/tmp/sensu.key
     - unless: apt-key list | grep '2048R/7580C77F.*expires'
 
-
 sensu-deb:
-  pkgrepo.managed:
+  pkgrepo.absent:
     - humanname: Sensu repo
     - name: deb http://repos.sensuapp.org/apt sensu main
+    - file: /etc/apt/sources.list.d/sensu.list
+    - require:
+      - cmd: sensu-apt-key
+    - require_in:
+      - pkg.*
+
+sensu-deb2:
+  pkgrepo.managed:
+    - humanname: Sensu repo 2017
+    - name: deb https://sensu.global.ssl.fastly.net/apt {{ salt['grains.get']('oscodename', 'trusty') }} main
     - file: /etc/apt/sources.list.d/sensu.list
     - require:
       - cmd: sensu-apt-key


### PR DESCRIPTION
Getting 404 with current.

 ```
 Err http://repos.sensuapp.org sensu/main amd64 Packages
   404  Not Found
 Ign http://repos.sensuapp.org sensu/main Translation-en
 Fetched 1411 kB in 2s (495 kB/s)
 [ERROR   ] stderr: W: Failed to fetch http://repos.sensuapp.org/apt/dists/sensu/main/binary-amd64/Packages  404  Not Found

 E: Some index files failed to download. They have been ignored, or old ones used instead.
```
New one taken from https://sensuapp.org/docs/0.27/platforms/sensu-on-ubuntu-debian.html#install-sensu-core-repository